### PR TITLE
Add custom_support properties config option. Fixes LP#1783125

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -39,6 +39,12 @@ options:
     type: string
     default: "auto-sync/"
     description: "This is prefixed to the object name when uploading to glance."
+  custom_properties:
+    type: string
+    default: ""
+    description: >
+      YAML-formatted list of any custom properties to be set in glance
+      for the synced image, e.g. architecture, hypervisor_type.
   content_id_template:
     type: string
     default: "auto.sync"

--- a/hooks/hooks.py
+++ b/hooks/hooks.py
@@ -103,6 +103,7 @@ class MirrorsConfigServiceContext(OSContextGenerator):
                     region=config['region'],
                     cloud_name=config['cloud_name'],
                     user_agent=config['user_agent'],
+                    custom_properties=config['custom_properties'],
                     hypervisor_mapping=config['hypervisor_mapping'])
 
 

--- a/templates/mirrors.yaml
+++ b/templates/mirrors.yaml
@@ -7,3 +7,6 @@ region: {{ region }}
 cloud_name: {{ cloud_name }}
 content_id_template: {{ content_id_template }}
 hypervisor_mapping: {{ hypervisor_mapping }}
+{%- if custom_properties %}
+custom_properties: {{ custom_properties }}
+{% endif %}


### PR DESCRIPTION
This change adds "custom_properties" configuration option. The option allows operators to set custom glance image properties.

Our particular use case is arm64 images that need "hypervisor_type=kvm" and "hw_firmware_type=uefi".

This PR addresses [LP#1783125](https://bugs.launchpad.net/charm-glance-simplestreams-sync/+bug/1783125)